### PR TITLE
Fix video resizing issue initial loading

### DIFF
--- a/src/AppEditor.vue
+++ b/src/AppEditor.vue
@@ -616,7 +616,7 @@ export default {
       return this.uiData.getLabel(name, this.lang);
     },
     getPlaytimeAsVttTime() {
-      return this.helper.vttTimestamp(this.playTime);
+      return (this.playTime == "-" ? this.playTime : this.helper.vttTimestamp(this.playTime));
     },
     getScfStartOffsetFrames() {
       return this.config.defaultOffsetFrames;

--- a/src/mediaComponents/VideoGeneric.vue
+++ b/src/mediaComponents/VideoGeneric.vue
@@ -46,3 +46,10 @@ export default {
   }
 };
 </script>
+
+<style scoped>
+div video {
+  width: 0px;
+  height: 0px;
+}
+</style>


### PR DESCRIPTION
- Default video size to full width and height when
  no other value applies. This leads to undesired rendering
  before the computed video width and height are calculated.
  As a workaround, the initial video width and height need to be
  set statically.

- Another loading issue affects the playtime. Before the playtime of
  the video is retrieved, the error isNaN is displayed. Another string
  should replace this error message.

- Closes #23 