### PR TITLE
Change labels in quality dropdown

### DIFF
--- a/src/config/burnerConfig.js
+++ b/src/config/burnerConfig.js
@@ -27,8 +27,8 @@ var proto = {
       height: 180
     }
   ],
-  defaultExportQuality: 23,
-  qualityOptions: [15, 20, 23, 26],
+  defaultExportQuality: "medium",
+  qualityOptions: { low: 26, medium: 21, high: 15 },
   url: "http://localhost:9010" // TODO
 };
 

--- a/src/editorComponents/BurnIn.vue
+++ b/src/editorComponents/BurnIn.vue
@@ -38,7 +38,7 @@
         class="floatBox"
         :options="videoOptions"
         :selected="selectedVideo"
-        :labelName="'Video source'"
+        :labelName="getLabelText('videoSource')"
         @valueChanged="setSelectedVideo"
       />
       <!-- video resolution -->
@@ -46,7 +46,7 @@
         class="floatBox"
         :options="getResolutionOpts()"
         :selected="selectedResolution"
-        :labelName="'Output Resolution'"
+        :labelName="getLabelText('outputResolution')"
         @valueChanged="setResolution"
       />
       <!-- video quality -->
@@ -54,7 +54,7 @@
         class="floatBox"
         :options="getQualityOptions()"
         :selected="selectedQuality"
-        :labelName="'Output quality (lower number = higher bitrate)'"
+        :labelName="getLabelText('outputQuality')"
         @valueChanged="setQuality"
       />
       <!-- subtitles, pngs -->
@@ -133,7 +133,7 @@ export default {
       progressPercentage: 0,
       progressText: "",
       selectedPngs: "",
-      selectedQuality: `${burnerConfig.defaultExportQuality}`,
+      selectedQuality: burnerConfig.defaultExportQuality,
       selectedResolution: "source",
       selectedUseCurrentST: "yes",
       selectedVideo: "",
@@ -212,7 +212,10 @@ export default {
       let selectedResCopy = this.selectedResolution;
       if (this.selectedResolution === "source") selectedResCopy = "";
       formData.append("resolution", selectedResCopy);
-      formData.append("quality", this.selectedQuality);
+      formData.append(
+        "quality",
+        this.burnerConfig.qualityOptions[this.selectedQuality]
+      );
       fetch(`${this.burnerConfig.url}/jobs`, {
         method: "POST",
         body: formData
@@ -291,7 +294,7 @@ export default {
     },
 
     getQualityOptions() {
-      return this.burnerConfig.qualityOptions.map(opt => `${opt}`);
+      return Object.keys(this.burnerConfig.qualityOptions);
     },
     getResolutionOpts() {
       let choices = ["source"];
@@ -311,7 +314,7 @@ export default {
       this.selectedVideo = "";
       this.selectedResolution = "source";
       this.selectedPngs = "";
-      this.selectedQuality = `${burnerConfig.defaultExportQuality}`;
+      this.selectedQuality = burnerConfig.defaultExportQuality;
       this.selectedUseCurrentST = "yes";
     },
     setQuality(val) {

--- a/src/modules/uiCentral.js
+++ b/src/modules/uiCentral.js
@@ -390,6 +390,22 @@ var proto = {
         }
       }
     },
+    outputQuality: {
+      label: {
+        lang: {
+          en: "Output quality",
+          de: "Ausgabequalität"
+        }
+      }
+    },
+    outputResolution: {
+      label: {
+        lang: {
+          en: "Output Resolution",
+          de: "Ausgabeauflösung"
+        }
+      }
+    },
     savePng: {
       label: {
         lang: {
@@ -643,6 +659,14 @@ var proto = {
         lang: {
           en: "Video",
           de: "Video"
+        }
+      }
+    },
+    videoSource: {
+      label: {
+        lang: {
+          en: "Video source",
+          de: "Video (Quelldatei)"
         }
       }
     },


### PR DESCRIPTION
- Output quality for burn-in service should be displayed in
  meaningful words rather than a number.

- Burnin properties should have a label in german.

- Closes #27 