### PR TITLE
Remove feature to export png feature

### DIFF
--- a/src/editorComponents/BurnIn.vue
+++ b/src/editorComponents/BurnIn.vue
@@ -58,7 +58,7 @@
         @valueChanged="setQuality"
       />
       <!-- subtitles, pngs -->
-      <RadioGeneric
+      <!-- <RadioGeneric
         :class="[{ radio: uiLayout != 'plain' }, 'clear', 'floatBox']"
         :options="['yes', 'no']"
         :selected="selectedUseCurrentST"
@@ -72,7 +72,7 @@
         :id="'choosePNG'"
         :labelText="getLabelText('choosePNG')"
         @filechange="setSubtitlePngs"
-      />
+      /> -->
       <ButtonGeneric
         class="clear floatBox"
         :buttonName="getLabelText('burnInSubmit')"

--- a/src/editorComponents/bootstrapComponents/MenuBarBS.vue
+++ b/src/editorComponents/bootstrapComponents/MenuBarBS.vue
@@ -97,9 +97,9 @@
             {{ getLabelText("saveXml") }}
           </b-dropdown-item-button>
           <!-- Export ISD as PNG  -->
-          <b-dropdown-item-button @click.native="saveIsdAsPng">
+          <!--    <b-dropdown-item-button @click.native="saveIsdAsPng">
             {{ getLabelText("saveIsdAsPng") }}
-          </b-dropdown-item-button>
+          </b-dropdown-item-button> -->
         </b-nav-item-dropdown>
       </b-navbar-nav>
 

--- a/src/editorComponents/plainComponents/MenuBarPlain.vue
+++ b/src/editorComponents/plainComponents/MenuBarPlain.vue
@@ -31,9 +31,9 @@
       <button @click="saveXml" class="menu-element">
         {{ getLabelText("saveXml") }}
       </button>
-      <button @click="saveIsdAsPng" class="menu-element">
+      <!--      <button @click="saveIsdAsPng" class="menu-element">
         {{ getLabelText("saveIsdAsPng") }}
-      </button>
+      </button> -->
       <button
         v-if="activateBurnIn"
         @click="toggleShowBurnIn"


### PR DESCRIPTION
- As burn-in service includes already exporting 
  subtitles as png, the png-export feature alone
  may confuse users, so it should be taken out
  (including the option in the burn-in service
  to select an archive of png instead of exporting/
  using the current ones

- Closes #28 